### PR TITLE
add purchase reserve method

### DIFF
--- a/src/backend/Gemfile
+++ b/src/backend/Gemfile
@@ -28,6 +28,8 @@ gem 'bootsnap', '>= 1.1.0', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'
 
+gem 'activerecord-import'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
@@ -48,3 +50,9 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'active_model_serializers', '~> 0.10.0'
 gem 'devise'
 gem 'devise_token_auth'
+
+group :development, :test do
+  gem 'pry-rails'
+  gem 'pry-byebug'
+  gem 'pry-doc'
+end

--- a/src/backend/Gemfile.lock
+++ b/src/backend/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
       activemodel (= 5.2.2)
       activesupport (= 5.2.2)
       arel (>= 9.0)
+    activerecord-import (0.27.0)
+      activerecord (>= 3.2)
     activestorage (5.2.2)
       actionpack (= 5.2.2)
       activerecord (= 5.2.2)
@@ -55,6 +57,7 @@ GEM
     byebug (10.0.2)
     case_transform (0.2)
       activesupport
+    coderay (1.1.2)
     concurrent-ruby (1.1.3)
     crass (1.0.4)
     devise (4.5.0)
@@ -95,6 +98,17 @@ GEM
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     orm_adapter (0.5.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-byebug (3.6.0)
+      byebug (~> 10.0)
+      pry (~> 0.10)
+    pry-doc (0.13.5)
+      pry (~> 0.11)
+      yard (~> 0.9.11)
+    pry-rails (0.3.8)
+      pry (>= 0.10.4)
     puma (3.12.0)
     rack (2.0.6)
     rack-test (1.1.0)
@@ -152,18 +166,23 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    yard (0.9.16)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   active_model_serializers (~> 0.10.0)
+  activerecord-import
   bootsnap (>= 1.1.0)
   byebug
   devise
   devise_token_auth
   listen (>= 3.0.5, < 3.2)
   mysql2 (>= 0.4.4, < 0.6.0)
+  pry-byebug
+  pry-doc
+  pry-rails
   puma (~> 3.11)
   rails (~> 5.2.2)
   spring

--- a/src/backend/app/controllers/purchases_controller.rb
+++ b/src/backend/app/controllers/purchases_controller.rb
@@ -3,19 +3,19 @@ class PurchasesController < ApplicationController
 
   def reserve
     purchase = Purchase.new(status: :waiting)
-    purchase.save
-    purchased_product = params["_json"].map do |param|
-      PurchasedProduct.new(product_id: param[:product_id], quantity: param[:quantity], purchase_id: purchase.id)
+    params["_json"].map do |param|
+      purchase.purchased_product.new(product_id: param[:product_id], quantity: param[:quantity])
     end
 
-    if (PurchasedProduct.import purchased_product).failed_instances.empty?
-      render json: purchased_product, status: :created
+    if purchase.save
+      render json: purchase.purchased_product, status: :created
       # felica readerをactiveにする処理
       # purchase_idも一緒に送る
     else
       render json: { errors: purchase.errors }, status: :unprocessable_entity
     end
   end
+
 
   def create
     purchase = Purchase.find(params[:purchase_id])

--- a/src/backend/app/controllers/purchases_controller.rb
+++ b/src/backend/app/controllers/purchases_controller.rb
@@ -8,7 +8,7 @@ class PurchasesController < ApplicationController
     end
 
     if purchase.save
-      render json: purchase.purchased_product, status: :created
+      render json: purchase, status: :created
       # felica readerをactiveにする処理
       # purchase_idも一緒に送る
     else

--- a/src/backend/app/controllers/purchases_controller.rb
+++ b/src/backend/app/controllers/purchases_controller.rb
@@ -1,0 +1,33 @@
+class PurchasesController < ApplicationController
+  before_action :authenticate_user!
+
+  def reserve
+    purchase = Purchase.new(status: :waiting)
+    purchase.save
+    purchased_product = params["_json"].map do |param|
+      PurchasedProduct.new(product_id: param[:product_id], quantity: param[:quantity], purchase_id: purchase.id)
+    end
+
+    if (PurchasedProduct.import purchased_product).failed_instances.empty?
+      render json: purchased_product, status: :created
+      # felica readerをactiveにする処理
+      # purchase_idも一緒に送る
+    else
+      render json: { errors: purchase.errors }, status: :unprocessable_entity
+    end
+  end
+
+  def create
+    purchase = Purchase.find(params[:purchase_id])
+    user = User.find(Idm.find_by(value: params[:idm]).user_id)
+    if purchase && user
+      purchase.user_id = user.id
+      if purchase.save
+        render json: purchase, status: :created
+      else
+        render json: {errors: purchase.errors}, status: :unprocessable_entity
+      end
+    end
+  end
+
+end

--- a/src/backend/app/models/purchase.rb
+++ b/src/backend/app/models/purchase.rb
@@ -1,3 +1,4 @@
 class Purchase < ApplicationRecord
   has_many :purchased_product, dependent: :destroy
+  enum status: { waiting: 0, success: 1, failed: 2}
 end

--- a/src/backend/app/serializers/purchase_serializer.rb
+++ b/src/backend/app/serializers/purchase_serializer.rb
@@ -1,3 +1,4 @@
 class PurchaseSerializer < ActiveModel::Serializer
   attributes :id, :user_id, :status
+  has_many :purchased_product
 end

--- a/src/backend/app/serializers/purchase_serializer.rb
+++ b/src/backend/app/serializers/purchase_serializer.rb
@@ -1,0 +1,3 @@
+class PurchaseSerializer < ActiveModel::Serializer
+  attributes :id, :user_id, :status
+end

--- a/src/backend/app/serializers/purchased_product_serializer.rb
+++ b/src/backend/app/serializers/purchased_product_serializer.rb
@@ -1,0 +1,3 @@
+class PurchasedProductSerializer < ActiveModel::Serializer
+  attributes :id, :purchase_id, :quantity, :product_id
+end

--- a/src/backend/config/routes.rb
+++ b/src/backend/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
     scope :v1 do
       mount_devise_token_auth_for 'User', at: 'auth'
       resources :products, only: [:index, :create, :show]
+      resources :purchases, only: [:create]
+      post "purchase/reserve" => "purchases#reserve"
     end
   end
 end

--- a/src/backend/db/migrate/20181208141205_create_purchases.rb
+++ b/src/backend/db/migrate/20181208141205_create_purchases.rb
@@ -2,7 +2,7 @@ class CreatePurchases < ActiveRecord::Migration[5.2]
   def change
     create_table :purchases do |t|
       t.integer :user_id
-      t.string :status, null: false, :default => "waiting" # success / waiting / failed
+      t.integer :status, null: false, :default => 0 # 0: waiting, 1: success, 2: failed
       t.timestamps
     end
   end

--- a/src/backend/db/migrate/20181209012929_purchase_status.rb
+++ b/src/backend/db/migrate/20181209012929_purchase_status.rb
@@ -1,0 +1,8 @@
+class PurchaseStatus < ActiveRecord::Migration[5.2]
+  def change
+    create_table :purchases_status do |t|
+      t.string :status
+      t.timestamps
+    end
+  end
+end

--- a/src/backend/db/schema.rb
+++ b/src/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_08_141302) do
+ActiveRecord::Schema.define(version: 2018_12_09_012929) do
 
   create_table "idms", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "user_id", null: false
@@ -38,8 +38,14 @@ ActiveRecord::Schema.define(version: 2018_12_08_141302) do
   end
 
   create_table "purchases", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "user_id", null: false
-    t.boolean "paid", default: false, null: false
+    t.integer "user_id"
+    t.integer "status", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "purchases_status", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
@@ -51,12 +57,27 @@ ActiveRecord::Schema.define(version: 2018_12_08_141302) do
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "password", null: false
-    t.integer "balance", null: false
-    t.integer "role_id", null: false
+    t.string "provider", default: "email", null: false
+    t.string "uid", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.boolean "allow_password_change", default: false
+    t.datetime "remember_created_at"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.string "name"
+    t.string "email"
+    t.integer "balance"
+    t.text "tokens"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
 end

--- a/src/backend/db/seeds.rb
+++ b/src/backend/db/seeds.rb
@@ -1,8 +1,8 @@
 Role.create(name: "admin")
 Role.create(name: "panpy")
 
-User.create(name: "しゃりかえ", password: "3lkjas0d98f34l3jk4t", balance: 3500, role_id: 2)
-User.create(name: "いしぐろ", password: "3lkh4jg0dfkj345hl23", balance: 10000, role_id: 2)
+User.create(name: "sharikae", email: "sharikae@example.com", password: "3lkjas0d98f34l3jk4t", balance: 3500)
+User.create(name: "ishiguro", email: "ishiguro@example.com", password: "3lkh4jg0dfkj345hl23", balance: 10000)
 
 Idm.create(user_id: 1, value: "123abc")
 Idm.create(user_id: 2, value: "456def")
@@ -10,8 +10,8 @@ Idm.create(user_id: 2, value: "456def")
 Product.create(name: "カップラーメン", price: 130, image: "https://3.bp.blogspot.com/-rZMHLcW6Er4/WlGpO69KN7I/AAAAAAABJlg/KgmrOkMSuoM0Xf0qRil3iOpMlGer-ypmACLcBGAs/s800/food_cup_ramen_miso.png", deleted: false)
 Product.create(name: "アイス", price: 100, image: "https://2.bp.blogspot.com/-t7fJ99VE-HY/W64DlIeosgI/AAAAAAABPH8/fzyUKstvUT0mu7Aqt1em7Lms0ttprj_tQCLcBGAs/s800/icecream_cup_spoon_wood.png", deleted: false)
 
-Purchase.create(user_id: 1, paid: false)
-Purchase.create(user_id: 1, paid: true)
+Purchase.create(user_id: 1, status: 0)
+Purchase.create(user_id: 1, status: 1)
 
 PurchasedProduct.create(purchase_id: 1, quantity: 2, product_id: 1)
 PurchasedProduct.create(purchase_id: 2, quantity: 1, product_id: 2)


### PR DESCRIPTION
# やったこと
  * `purchase_contorller`追加
    * `reserve` メソッド追加(frontendから送られる購買情報を処理する)
    * `create` メソッド追加(felica managerから送られるidmを処理する)
  * routing追加した
  * `puchase_serializer`, `purchased_product_serializer`追加した

## ほか
  * `pry`追加した (`binding.pry`ででバックできるようになるgem)
  * `activerecord-import`追加した(ActiveRecortでbulk insertできるようになるgem)
  * userの変更に伴ってseeder変更した

## 備考
動作確認で使ったjsonたち

### sign_in
endpoint: `base_url/api/v1/auth/sign_in` `POST`
body: 
```
{
  "email": "ishiguro@example.com",
  "password": "3lkh4jg0dfkj345hl23"
}
```

####  以降つけるheader 
  * access-token
  * client
  * uid

### purchase reserve
endpoint: `base_url/api/v1/purchase/reserve` `POST`
body:
```
[
  {
    "product_id": 1,
    "quantity":2
  },
  {
    "product_id": 2,
    "quantity": 1
  }
]
```

### purchase create 
endpoint: `base_url/api/v1/purchase` `POST`
body:
```
{
  "purchase_id": 1,
  "idm": "456def"
}
```